### PR TITLE
[bugfix][backward-incompatible] simplify the template for `ntp.conf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Release x.y.z
+
+This release introduces backward-incompatibilities.
+
+The following variables are removed from the role.
+
+* `ntpd_role`
+* `ntpd_upstreams`
+* `ntpd_pools`
+
+The template for `ntp.conf` is now empty by default. Define `ntpd_config` and
+build your own configuration.
+
 ## Release 1.4.0
 
 * 1471b51 [feature][bugfix] remove obsolete modules and attributes, support FreeBSD 11.1 (#3)

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
 gem "infrataster", "~> 0.3.2", git: "https://github.com/trombik/infrataster.git", branch: "reallyenglish"
-gem "kitchen-ansible", "~> 0.40.1", git: "https://github.com/trombik/kitchen-ansible.git", branch: "freebsd_support" # use patched kitchen-ansible
+gem "kitchen-ansible", "~> 0.48"
 gem "kitchen-sync", "~> 2.1.1", git: "https://github.com/trombik/kitchen-sync.git", branch: "without_full_path_to_rsync"
 gem "kitchen-vagrant", "~> 0.20.0"
-gem "kitchen-verifier-serverspec", "~> 0.3.0"
 gem "kitchen-verifier-shell", "~> 0.2.0"
 gem "rake", "~> 11.1.2"
 gem "rspec", "~> 3.4.0"

--- a/README.md
+++ b/README.md
@@ -12,22 +12,14 @@ None
 |----------|-------------|---------|
 | `ntpd_service` | service name of `ntpd` | `{{ __ntpd_service }}` |
 | `ntpd_conf` | path to `ntp.conf` | `{{ __ntpd_conf }}` |
+| `ntpd_config` | content of `ntp.conf` | `""` |
 | `ntpd_db_dir` | path to directory where `ntpd.leap-seconds.list` is kept | `{{ __ntpd_db_dir }}` |
 | `ntpd_script_dir` | directory to keep support script. this must be included in PATH environment variable | `{{ __ntpd_script_dir }}` |
 | `ntpd_leapfile` | path to `leap-seconds.list` If the value is empty string, `leapfile` setting is not added to `ntp.conf` | `{{ ntpd_db_dir }}/leap-seconds.list` |
 | `ntpd_package` | package name of `ntpd` | `{{ __ntpd_package }}` |
 | `ntpd_driftfile` | path to `ntp.drift` | `{{ ntpd_db_dir }}/ntp.drift` |
 | `ntpd_leap_seconds_url` | URL of `leap-seconds.list`. If the value is empty string, the file is not downloaded. | `https://www.ietf.org/timezones/data/leap-seconds.list` |
-| `ntpd_role` | NTP client or server (server is not implemented) | `client` |
-| `ntpd_upstreams` | list of upstream | `[]` |
-| `ntpd_pools` | list of pool | `{% if ntpd_supports_pool %}[ '0.pool.ntp.org' ]{% else %}[ '0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org' ]{% endif %}` |
 
-## `ntpd_pools`
-
-Servers provided by DNS round robin must be added to `ntpd_pools` because
-special treatment for restrictions is required.  ntpd >= 4.2.7 supports `pool`
-directive and a delegate pool name can be used.  see
-http://support.ntp.org/bin/view/Support/ConfiguringNTP#Section_6.10 for detail
 
 ## `ntpd_supports_pool`
 
@@ -74,17 +66,48 @@ None
   roles:
     - ansible-role-ntpd
   vars:
-    ntpd_upstreams:
+    upstreams:
       - time1.google.com
       - time2.google.com
       - time3.google.com
       - time4.google.com
+    # Servers provided by DNS round robin must be added to `pools` because
+    # special treatment for restrictions is required.  ntpd >= 4.2.7 supports `pool`
+    # directive and a delegate pool name can be used.  see
+    # http://support.ntp.org/bin/view/Support/ConfiguringNTP#Section_6.10 for detail
+    pools:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+    ntpd_config: |
+      {% for s in upstreams %}
+      server {{ s }} iburst
+      restrict {{ s }} nomodify notrap noquery
+      {% endfor %}
+
+      {% if ntpd_supports_pool %}
+      restrict default ignore
+      restrict -6 default ignore
+      pool {{ pools | first }} iburst
+      restrict source nomodify noquery notrap
+      {% else %}
+      restrict default -4 nomodify nopeer noquery notrap
+      restrict default -6 nomodify nopeer noquery notrap
+      {% for p in pools %}
+      server {{ p }} iburst
+      {% endfor %}
+      {% endif %}
+
+      restrict localhost
+      leapfile "{{ ntpd_leapfile }}"
+      driftfile "{{ ntpd_driftfile }}"
 ```
 
 # License
 
 ```
-Copyright (c) 2016 Tomoyuki Sakurai <tomoyukis@reallyenglish.com>
+Copyright (c) 2016 Tomoyuki Sakurai <y@trombik.org>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -101,4 +124,4 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 # Author Information
 
-Tomoyuki Sakurai <tomoyukis@reallyenglish.com>
+Tomoyuki Sakurai <y@trombik.org>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,9 @@
 ntpd_service: "{{ __ntpd_service }}"
 ntpd_conf: "{{ __ntpd_conf }}"
+ntpd_config: ""
 ntpd_db_dir: "{{ __ntpd_db_dir }}"
 ntpd_script_dir: "{{ __ntpd_script_dir }}"
 ntpd_leapfile: "{{ ntpd_db_dir }}/leap-seconds.list"
 ntpd_package: "{{ __ntpd_package }}"
 ntpd_driftfile: "{{ ntpd_db_dir }}/ntp.drift"
 ntpd_leap_seconds_url: "https://www.ietf.org/timezones/data/leap-seconds.list"
-
-ntpd_role: client
-ntpd_upstreams: []
-ntpd_pools: "{% if ntpd_supports_pool %}[ '0.pool.ntp.org' ]{% else %}[ '0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org' ]{% endif %}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,9 +41,8 @@
   template:
     src: ntpd.conf.client.j2
     dest: "{{ ntpd_conf }}"
-    validate: "ansible-ntpd-checkconf %s"
+    validate: "{{ ntpd_script_dir }}/ansible-ntpd-checkconf %s"
   notify: Restart ntpd
-  when: ntpd_role == 'client'
 
 - name: Start ntpd
   service:

--- a/templates/ntpd.conf.client.j2
+++ b/templates/ntpd.conf.client.j2
@@ -1,28 +1,3 @@
-{% for s in ntpd_upstreams %}
-server {{ s }} iburst
-restrict {{ s }} nomodify notrap noquery
-{% endfor %}
-{% if ( ntpd_pools | length == 0 ) or ntpd_supports_pool %}
-restrict default ignore
-restrict -6 default ignore
-{% else %}
-restrict default -4 nomodify nopeer noquery notrap
-restrict default -6 nomodify nopeer noquery notrap
-{% endif %}
-{% if ( ntpd_pools | length > 0 ) %}
-{% if ntpd_supports_pool %}
-{% for ntpd_pool in ntpd_pools %}
-pool {{ ntpd_pool }} iburst
-{% endfor %}
-restrict source nomodify noquery notrap
-{% else %}
-{% for ntpd_pool in ntpd_pools %}
-server {{ ntpd_pool }} iburst
-{% endfor %}
-{% endif %}
-{% endif %}
-restrict localhost
-{% if ntpd_leapfile | length > 0 %}
-leapfile "{{ ntpd_leapfile }}"
-{% endif %}
-driftfile "{{ ntpd_driftfile }}"
+# Managed by ansible
+
+{{ ntpd_config }}

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -2,8 +2,39 @@
   roles:
     - ansible-role-ntpd
   vars:
-    ntpd_upstreams:
+    upstreams:
       - time1.google.com
       - time2.google.com
       - time3.google.com
       - time4.google.com
+    # Servers provided by DNS round robin must be added to `pools` because
+    # special treatment for restrictions is required.  ntpd >= 4.2.7 supports `pool`
+    # directive and a delegate pool name can be used.  see
+    # http://support.ntp.org/bin/view/Support/ConfiguringNTP#Section_6.10 for detail
+    pools:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+    ntpd_config: |
+      {% for s in upstreams %}
+      server {{ s }} iburst
+      restrict {{ s }} nomodify notrap noquery
+      {% endfor %}
+
+      {% if ntpd_supports_pool %}
+      restrict default ignore
+      restrict -6 default ignore
+      pool {{ pools | first }} iburst
+      restrict source nomodify noquery notrap
+      {% else %}
+      restrict default -4 nomodify nopeer noquery notrap
+      restrict default -6 nomodify nopeer noquery notrap
+      {% for p in pools %}
+      server {{ p }} iburst
+      {% endfor %}
+      {% endif %}
+
+      restrict localhost
+      leapfile "{{ ntpd_leapfile }}"
+      driftfile "{{ ntpd_driftfile }}"

--- a/tests/serverspec/without_leapfile.yml
+++ b/tests/serverspec/without_leapfile.yml
@@ -7,5 +7,30 @@
       - time2.google.com
       - time3.google.com
       - time4.google.com
-    ntpd_leapfile: ""
+    ntpd_pools:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
     ntpd_leap_seconds_url: ""
+    ntpd_config: |
+      {% for s in ntpd_upstreams %}
+      server {{ s }} iburst
+      restrict {{ s }} nomodify notrap noquery
+      {% endfor %}
+
+      {% if ntpd_supports_pool %}
+      restrict default ignore
+      restrict -6 default ignore
+      pool {{ ntpd_pools | first }} iburst
+      restrict source nomodify noquery notrap
+      {% else %}
+      restrict default -4 nomodify nopeer noquery notrap
+      restrict default -6 nomodify nopeer noquery notrap
+      {% for p in ntpd_pools %}
+      server {{ p }} iburst
+      {% endfor %}
+      {% endif %}
+
+      restrict localhost
+      driftfile "{{ ntpd_driftfile }}"

--- a/tests/serverspec/without_leapfile.yml
+++ b/tests/serverspec/without_leapfile.yml
@@ -2,19 +2,19 @@
   roles:
     - ansible-role-ntpd
   vars:
-    ntpd_upstreams:
+    upstreams:
       - time1.google.com
       - time2.google.com
       - time3.google.com
       - time4.google.com
-    ntpd_pools:
+    pools:
       - 0.pool.ntp.org
       - 1.pool.ntp.org
       - 2.pool.ntp.org
       - 3.pool.ntp.org
     ntpd_leap_seconds_url: ""
     ntpd_config: |
-      {% for s in ntpd_upstreams %}
+      {% for s in upstreams %}
       server {{ s }} iburst
       restrict {{ s }} nomodify notrap noquery
       {% endfor %}
@@ -22,12 +22,12 @@
       {% if ntpd_supports_pool %}
       restrict default ignore
       restrict -6 default ignore
-      pool {{ ntpd_pools | first }} iburst
+      pool {{ pools | first }} iburst
       restrict source nomodify noquery notrap
       {% else %}
       restrict default -4 nomodify nopeer noquery notrap
       restrict default -6 nomodify nopeer noquery notrap
-      {% for p in ntpd_pools %}
+      {% for p in pools %}
       server {{ p }} iburst
       {% endfor %}
       {% endif %}


### PR DESCRIPTION
This removes hard-coded logics in the template, which also introduces
backward-incompatibilities.

fixes #5 

